### PR TITLE
PLAT-184: Add manifest list subcommand to CLI

### DIFF
--- a/datajoint_file_validator/cli.py
+++ b/datajoint_file_validator/cli.py
@@ -1,12 +1,13 @@
 import sys
 import typer
 from enum import Enum
+from typing import List, Dict, Any, Optional
 from typing_extensions import Annotated
 import yaml
 from rich import print as rprint
 from rich.console import Console
 from rich.table import Table
-from . import main
+from . import main, registry
 
 console = Console()
 app = typer.Typer()
@@ -54,3 +55,28 @@ def validate(
     elif format == DisplayFormat.json:
         rprint(report)
     raise typer.Exit(code=1)
+
+
+@app.command()
+def list_manifests(
+    query: Optional[str] = typer.Option(
+        None,
+        help="Filter manifest names using this regular expression query",
+    ),
+    format: DisplayFormat = DisplayFormat.table,
+):
+    """
+    List all available manifests.
+    """
+    manifests: List[Dict[str, Any]] = registry.list_manifests(query=query)
+    rprint(f"Found {len(manifests)} manifests:")
+
+    # if format == DisplayFormat.table:
+    #     table = main.table_from_report(report)
+    #     console = Console()
+    #     console.print(table)
+    # elif format == DisplayFormat.yaml:
+    #     rprint(file=sys.stderr)
+    #     rprint(yaml.dump(report))
+    # elif format == DisplayFormat.json:
+    #     rprint(report)

--- a/datajoint_file_validator/cli.py
+++ b/datajoint_file_validator/cli.py
@@ -71,12 +71,12 @@ def list_manifests(
     manifests: List[Dict[str, Any]] = registry.list_manifests(query=query)
     rprint(f"Found {len(manifests)} manifests:")
 
-    # if format == DisplayFormat.table:
-    #     table = main.table_from_report(report)
-    #     console = Console()
-    #     console.print(table)
-    # elif format == DisplayFormat.yaml:
-    #     rprint(file=sys.stderr)
-    #     rprint(yaml.dump(report))
-    # elif format == DisplayFormat.json:
-    #     rprint(report)
+    if format == DisplayFormat.table:
+        table = registry.table_from_manifest_list(manifests)
+        console = Console()
+        console.print(table)
+    elif format == DisplayFormat.yaml:
+        rprint(file=sys.stderr)
+        rprint(yaml.dump(manifests))
+    elif format == DisplayFormat.json:
+        rprint(manifests)

--- a/datajoint_file_validator/cli.py
+++ b/datajoint_file_validator/cli.py
@@ -11,6 +11,8 @@ from . import main, registry
 
 console = Console()
 app = typer.Typer()
+manifest_app = typer.Typer(name="manifest")
+app.add_typer(manifest_app, name="manifest")
 
 
 @app.callback()
@@ -57,7 +59,7 @@ def validate(
     raise typer.Exit(code=1)
 
 
-@app.command()
+@manifest_app.command(name="list")
 def list_manifests(
     query: Optional[str] = typer.Option(
         None,
@@ -69,8 +71,6 @@ def list_manifests(
     List all available manifests.
     """
     manifests: List[Dict[str, Any]] = registry.list_manifests(query=query)
-    rprint(f"Found {len(manifests)} manifests:")
-
     if format == DisplayFormat.table:
         table = registry.table_from_manifest_list(manifests)
         console = Console()

--- a/datajoint_file_validator/log.py
+++ b/datajoint_file_validator/log.py
@@ -1,4 +1,5 @@
 import logging
+from .config import config
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.DEBUG if config.debug else logging.INFO)
 logger = logging.getLogger(__name__)

--- a/datajoint_file_validator/manifest.py
+++ b/datajoint_file_validator/manifest.py
@@ -27,6 +27,8 @@ class Manifest:
     description: Optional[str] = None
     uri: Optional[str] = None
     rules: List[Rule] = field(default_factory=list)
+    # Additional, unchecked metadata for the manifest
+    _meta: Dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
         if not self.id:

--- a/datajoint_file_validator/registry.py
+++ b/datajoint_file_validator/registry.py
@@ -29,6 +29,9 @@ def _get_try_paths(
         yield (Path(module_loc) / Path("manifests") / Path(query))
     # If query has no extension, try adding .yaml
     if query.suffix != ".yaml":
+        # Check if there is a file called `default.yaml`
+        # in a subdirectory named `query`
+        yield from _get_try_paths(Path(query) / Path("default.yaml"))
         for ext in try_extensions:
             yield from _get_try_paths(Path(str(query) + ext))
 
@@ -52,10 +55,6 @@ def find_manifest(query: str) -> Path:
         query = str(query)
 
     try_paths: List[Path] = list(_get_try_paths(query))
-    if not query.endswith(".yaml"):
-        # Check if there is a file called `default` or `default.yaml`
-        # in a subdirectory named `query`
-        try_paths.extend(_get_try_paths(Path(query) / Path("default")))
     # Remove duplicates while preserving order
     try_paths = list(dict.fromkeys(try_paths))
     logger.debug(f"Trying paths: {pf(try_paths)}")

--- a/datajoint_file_validator/registry.py
+++ b/datajoint_file_validator/registry.py
@@ -147,7 +147,7 @@ def table_from_manifest_list(manifests: List[Dict[str, Any]]) -> Table:
     table = Table(
         show_header=True,
         header_style="bold",
-        title="Available Manifests",
+        title=None,
         show_lines=True,
     )
     table.add_column("ID")

--- a/datajoint_file_validator/registry.py
+++ b/datajoint_file_validator/registry.py
@@ -4,6 +4,7 @@ from typing import List, Union, Generator, Tuple, Optional, Dict, Any
 from pprint import pformat as pf
 from wcmatch.pathlib import Path, GLOBSTAR
 from wcmatch.glob import glob
+from rich.table import Table
 from .manifest import Manifest
 from .config import config
 from .log import logger
@@ -113,7 +114,7 @@ def list_manifests(
             continue
         else:
             manifest._meta["path"] = str(path)
-            manifest._meta["name"] = str(path.stem)
+            manifest._meta["stem"] = str(path.stem)
             manifests.add(manifest)
     manifests = list(manifests)
 
@@ -127,3 +128,37 @@ def list_manifests(
             manifests = list(reversed(manifests))
 
     return [manifest.to_dict() for manifest in manifests]
+
+
+def table_from_manifest_list(manifests: List[Dict[str, Any]]) -> Table:
+    """
+    Create a rich table from a list of manifests' dictionary representations.
+
+    Parameters
+    ----------
+    manifests : List[Dict[str, Any]]
+        A list of manifests.
+
+    Returns
+    -------
+    Table
+        A rich table.
+    """
+    table = Table(
+        show_header=True,
+        header_style="bold",
+        title="Available Manifests",
+        show_lines=True,
+    )
+    table.add_column("ID")
+    table.add_column("Version")
+    table.add_column("Description")
+    table.add_column("Path", overflow="fold")
+    for manifest in manifests:
+        table.add_row(
+            manifest["id"],
+            manifest.get("version"),
+            manifest.get("description"),
+            manifest["_meta"]["path"],
+        )
+    return table

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -110,7 +110,8 @@ class TestValidate:
         result = runner.invoke(
             app,
             [
-                "list-manifests",
+                "manifest",
+                "list",
             ],
         )
         assert result.exit_code == 0
@@ -121,7 +122,8 @@ class TestValidate:
         result = runner.invoke(
             app,
             [
-                "list-manifests",
+                "manifest",
+                "list",
                 "--format",
                 fmt,
             ],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -105,3 +105,33 @@ class TestValidate:
             assert "constraint_id: count_min" in result.stdout
         elif fmt == "json":
             assert "'constraint_id': 'count_min'" in result.stdout
+
+    def test_list_manifests_basic(self, runner):
+        result = runner.invoke(
+            app,
+            [
+                "list-manifests",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "demo_dlc" in result.stdout
+
+    @pytest.mark.parametrize("fmt", ("table", "yaml", "json"))
+    def test_list_manifests_format(self, runner, fmt):
+        result = runner.invoke(
+            app,
+            [
+                "list-manifests",
+                "--format",
+                fmt,
+            ],
+        )
+        assert result.exit_code == 0
+        assert "demo_dlc" in result.stdout
+
+        if fmt == "table":
+            assert "━" in result.stdout
+        elif fmt == "yaml":
+            assert "name: demo_dlc" in result.stdout
+        elif fmt == "json":
+            assert "'name': 'demo_dlc'" in result.stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -132,6 +132,6 @@ class TestValidate:
         if fmt == "table":
             assert "━" in result.stdout
         elif fmt == "yaml":
-            assert "name: demo_dlc" in result.stdout
+            assert "stem: v0.1" in result.stdout
         elif fmt == "json":
-            assert "'name': 'demo_dlc'" in result.stdout
+            assert "'stem': 'v0.1'" in result.stdout

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -14,7 +14,9 @@ class TestManifest:
         """
         manifest_dict = read_yaml(manifest_file_from_registry)
         man1 = Manifest.from_dict(manifest_dict)
+        assert isinstance(man1.id, str)
         man2 = Manifest.from_yaml(manifest_file_from_registry)
+        assert isinstance(man2.id, str)
         assert man1 == man2
 
     def test_all_registry_manifests_valid(self, manifest_file_from_registry: str):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,8 +1,10 @@
 import os
 import pytest
 from pathlib import Path
+from pprint import pformat as pf
 from yaml import safe_dump
 from datajoint_file_validator import registry, Manifest
+from . import logger
 
 
 @pytest.fixture
@@ -69,3 +71,12 @@ def test_find_in_subdir_from_site_pkg_symlink():
     assert resolved.resolve().name == "v0.1.yaml"
     with pytest.raises(FileNotFoundError):
         resolved = registry.find_manifest("demo_dlc.yaml")
+
+
+def test_list_manifests_basic():
+    """Test registry.list_manifests"""
+    manifests = registry.list_manifests(query=None)
+    assert len(manifests) > 0
+    assert isinstance(manifests[0], dict)
+    logger.info(f"Found {len(manifests)} manifests:")
+    logger.info(pf(manifests))

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -85,7 +85,7 @@ def test_list_manifests_basic():
 
     # Test the query kwarg
     filtered_manis = registry.list_manifests(query="demo")
-    mani_names = [mani["_meta"]["name"] for mani in filtered_manis]
+    mani_names = [mani["_meta"]["stem"] for mani in filtered_manis]
     for mani_name in mani_names:
         assert "demo" in mani_name
 
@@ -102,7 +102,7 @@ def test_list_manifests_additional_dir(manifest_dict, tmp_path):
 
     manifests = registry.list_manifests(query=None, additional_dirs=[tmp_path])
     assert len(manifests) > 0
-    mani_names = [mani["_meta"]["name"] for mani in manifests]
+    mani_names = [mani["_meta"]["stem"] for mani in manifests]
     mani_ids = [mani["id"] for mani in manifests]
     assert "new_manifest" in mani_names
     assert "my_new_manifest" in mani_ids
@@ -118,7 +118,7 @@ def test_list_manifests_skips_unparseable(manifest_dict, tmp_path):
 
     manifests = registry.list_manifests(query=None, additional_dirs=[tmp_path])
     assert len(manifests) > 0
-    mani_names = [mani["_meta"]["name"] for mani in manifests]
+    mani_names = [mani["_meta"]["stem"] for mani in manifests]
     mani_ids = [mani["id"] for mani in manifests]
     assert "new_manifest" not in mani_names
     assert "my_new_manifest" not in mani_ids
@@ -130,10 +130,16 @@ def test_list_manifests_sort_alpha():
     manis_desc = registry.list_manifests(query=None, sort_alpha="desc")
     assert len(manis_asc) > 1
     assert len(manis_desc) > 1
-    assert manis_asc[0]["_meta"]["name"] < manis_asc[-1]["_meta"]["name"]
-    assert manis_desc[0]["_meta"]["name"] > manis_desc[-1]["_meta"]["name"]
+    assert manis_asc[0]["_meta"]["stem"] < manis_asc[-1]["_meta"]["stem"]
+    assert manis_desc[0]["_meta"]["stem"] > manis_desc[-1]["_meta"]["stem"]
     assert manis_asc[0] == manis_desc[-1]
     assert manis_asc[-1] == manis_desc[0]
 
     with pytest.raises(ValueError):
         registry.list_manifests(query=None, sort_alpha="gibberish")
+
+
+def test_table_from_manifest_list():
+    """Test registry.table_from_manifest_list"""
+    manifests = registry.list_manifests()
+    table = registry.table_from_manifest_list(manifests)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -80,3 +80,17 @@ def test_list_manifests_basic():
     assert isinstance(manifests[0], dict)
     logger.info(f"Found {len(manifests)} manifests:")
     logger.info(pf(manifests))
+
+def test_list_manifests_additional_dir(manifest_dict, tmp_path):
+    """Test registry.list_manifests with additional directory"""
+    new_manifest_path = tmp_path / "new_manifest.yaml"
+    manifest_dict["id"] = "my_new_manifest"
+    with open(new_manifest_path, "w") as f:
+        safe_dump(manifest_dict, f)
+
+    manifests = registry.list_manifests(query=None, additional_dirs=[tmp_path])
+    assert len(manifests) > 0
+    mani_names = [mani._meta["name"] for mani in manifests]
+    mani_ids = [mani._meta["id"] for mani in manifests]
+    assert "new_manifest" in mani_names
+    assert "my_new_manifest" in mani_ids


### PR DESCRIPTION
## Commits

- PLAT-186: Add pytests that check manifest dicts against snapshot dicts
- Add failing pytests for PLAT-184
- First pass that only checks top level of directory
- _get_try_paths traverses subdirs for default.yaml search
- list_manifests passing tests
- Failing pytest for additional_dirs kwarg
- Add additional_dirs kwarg
- Module logger uses config debug setting
- Passing list-manifests CLI pytests
- mv list-manifests to subcommand manifest list
